### PR TITLE
pkgconfig: convert hardlink to softlink

### DIFF
--- a/recipes-devtools/pkgconfig/files/0001-convert-hardlink-to-softlink.patch
+++ b/recipes-devtools/pkgconfig/files/0001-convert-hardlink-to-softlink.patch
@@ -1,0 +1,13 @@
+Index: pkg-config-0.28/Makefile.am
+===================================================================
+--- pkg-config-0.28.orig/Makefile.am
++++ pkg-config-0.28/Makefile.am
+@@ -39,7 +39,7 @@ pkg_config_SOURCES= \
+ if HOST_TOOL
+ host_tool = $(host)-pkg-config$(EXEEXT)
+ install-exec-hook:
+-	cd $(DESTDIR)$(bindir) && $(LN) pkg-config$(EXEEXT) $(host_tool)
++	cd $(DESTDIR)$(bindir) && $(LN) -sf pkg-config$(EXEEXT) $(host_tool)
+ uninstall-hook:
+ 	cd $(DESTDIR)$(bindir) && rm -f $(host_tool)
+ endif

--- a/recipes-devtools/pkgconfig/pkgconfig_%.bbappend
+++ b/recipes-devtools/pkgconfig/pkgconfig_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://0001-convert-hardlink-to-softlink.patch"


### PR DESCRIPTION
Since Vmware Fusion share folder doesn't support hardlink, we switch it
to softlink to prevent building failed.

Signed-off-by: Yen-Chin Lee coldnew.tw@gmail.com
